### PR TITLE
Add support for Checkout with PayPal flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Payment methods can accept preferences either directly entered in admin, or from
         environment: Rails.env.production? ? 'production' : 'sandbox',
         merchant_id: ENV['BRAINTREE_MERCHANT_ID'],
         public_key: ENV['BRAINTREE_PUBLIC_KEY'],
-        private_key: ENV['BRAINTREE_PRIVATE_KEY']
+        private_key: ENV['BRAINTREE_PRIVATE_KEY'],
+        paypal_flow: 'vault', # 'checkout' is accepted too
       }
     )
   end
@@ -155,8 +156,10 @@ store's configuration.
 The checkout view
 [initializes the PayPal button](/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb)
 using the
-[vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
-which allows the source to be reused.
+[Vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
+which allows the source to be reused. If you want, you can use [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3)
+instead, which doesn't allow you to reuse sources but allows your customers to pay with their PayPal
+balance (see setup instructions).
 
 If you are creating your own checkout view or would like to customize the
 [options that get passed to tokenize](https://braintree.github.io/braintree-web/3.6.3/PayPal.html#tokenize)

--- a/app/assets/javascripts/spree/frontend/paypal_button.js
+++ b/app/assets/javascripts/spree/frontend/paypal_button.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
       }).
       load(function() {
         var paypalOptions = {
-          flow: 'vault',
+          flow: window.payPalFlow,
           enableShippingAddress: true
         }
         var button = new SolidusPaypalBraintree.createPaypalButton(document.querySelector("#paypal-button"), paypalOptions);

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -38,6 +38,9 @@ module SolidusPaypalBraintree
     preference(:merchant_currency_map, :hash, default: {})
     preference(:paypal_payee_email_map, :hash, default: {})
 
+    # Which checkout flow to use (vault/checkout)
+    preference(:paypal_flow, :string, default: 'vault')
+
     def partial_name
       "paypal_braintree"
     end
@@ -286,7 +289,7 @@ module SolidusPaypalBraintree
       end
 
       params[:channel] = "Solidus"
-      params[:options] = { store_in_vault_on_success: true }
+      params[:options] = { store_in_vault_on_success: (preferred_paypal_flow == 'vault') }
 
       if submit_for_settlement
         params[:options][:submit_for_settlement] = true
@@ -357,7 +360,7 @@ module SolidusPaypalBraintree
     def customer_profile_params(payment)
       params = {}
 
-      if payment.source.try(:nonce)
+      if preferred_paypal_flow == 'vault' && payment.source.try(:nonce)
         params[:payment_method_nonce] = payment.source.nonce
       end
 

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -2,6 +2,10 @@
 <% id = payment_method.id %>
 
 <% content_for :head do %>
+  <script>
+    window.payPalFlow = '<%= SolidusPaypalBraintree::Gateway.first.preferred_paypal_flow %>';
+  </script>
+
   <script src="https://js.braintreegateway.com/web/3.22.1/js/client.min.js"></script>
   <script src="https://js.braintreegateway.com/web/3.22.1/js/data-collector.min.js"></script>
 
@@ -45,10 +49,12 @@
     }
 
     var paypalOptions = {
-      flow: 'vault',
+      flow: window.payPalFlow,
       enableShippingAddress: true,
       shippingAddressOverride: address,
-      shippingAddressEditable: false
+      shippingAddressEditable: false,
+      amount: '<%= current_order.total %>',
+      currency: '<%= current_order.currency %>'
     }
 
     var button = new SolidusPaypalBraintree.createPaypalButton(document.querySelector("#paypal-button"), paypalOptions);


### PR DESCRIPTION
Allows users to choose between Vaulting and Checkout with PayPal
via a gateway-level preference.